### PR TITLE
Refine pagination logic in search response.

### DIFF
--- a/src/ResponseModels/SearchResponseSchema.php
+++ b/src/ResponseModels/SearchResponseSchema.php
@@ -81,8 +81,9 @@ class SearchResponseSchema implements SearchResponseSchemaInterface
     {
         $pagination = $this->search()->pagination();
         $page = data_get($pagination, 'page');
+        $max = data_get($pagination, 'max');
 
-        return $page > 0 || $this->forcePagination;
+        return ($page > 0 && $max > 0) || $this->forcePagination;
     }
 
     /**
@@ -104,19 +105,18 @@ class SearchResponseSchema implements SearchResponseSchemaInterface
      */
     protected function mapWithPagination() : array
     {
-        $pagination = $this->search()->pagination();
-
         $mapWithPagination = [];
+        $itemKey = config('searches.responses.pagination_keys.items', 'items');
+        $mapWithPagination[$itemKey] = $this->map();
 
+        $this->search()->count();
+        $pagination = $this->search()->pagination();
         foreach ($pagination as $key => $value){
             $newKey = config("searches.responses.pagination_keys.{$key}", $key);
-
             //all pagination values should be integer values
             $mapWithPagination[$newKey] = (int) $value;
         }
 
-        $itemKey = config('searches.responses.pagination_keys.items', 'items');
-        $mapWithPagination[$itemKey] = $this->map();
 
         return $mapWithPagination;
     }

--- a/src/Search.php
+++ b/src/Search.php
@@ -257,10 +257,6 @@ class Search implements Searcher
      */
     public function pagination() : array
     {
-        if(is_null($this->pagination['total'])){
-            $this->count();
-        }
-
         return $this->pagination;
     }
 


### PR DESCRIPTION
Ensure `pagination` values are integers and enhance key mapping flexibility. Adjust conditions to include `max` in validation and optimize method order for clarity and correctness. Remove redundant `count()` invocation in `pagination()`.